### PR TITLE
Add install RPM GPG key task to redhat variant

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -13,6 +13,11 @@
   register: __postgresql_repo_pkg_installed_result
   ignore_errors: true
 
+- name: Install pgdg key
+  rpm_key:
+    key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+  when: __postgresql_repo_pkg_installed_result is failed
+
 - name: Install pgdg repository package (RedHat)
   yum:
     name: >-


### PR DESCRIPTION
Without this task, the repo installation failed during Rocky 9 testing